### PR TITLE
Added Certificate Date Validation

### DIFF
--- a/library/CertificateDateValidation/config.yml
+++ b/library/CertificateDateValidation/config.yml
@@ -1,0 +1,19 @@
+name: CertificateDateValidation
+description: >
+  The synthetic script can be used to validate an SSL or TLS certificate's date. When configured,
+  the script will call a URL endpoint and get the Peer Certificate. The certificate can then be
+  analyzed for its expiration date and compared with an offset of a specified amount of days to
+  trigger a check failure to ensure than the endpoints get updated when required.
+
+# Type of synthetic quickstart
+# - Template (Default): Full example that users can copy paste to use
+# - Snippet: Code example or building block for users to use in their own synthetic scripts
+type: Template
+
+# Type of synthetic monitor
+# Scripted Browser = SCRIPT_BROWSER
+# Scripted API = SCRIPT_API
+monitorType: SCRIPT_API
+
+authors:
+    - Brian Rogers

--- a/library/CertificateDateValidation/script.js
+++ b/library/CertificateDateValidation/script.js
@@ -1,0 +1,80 @@
+/**
+ * When creating the script, setting it as an API test simplifies the results
+ * https://docs.newrelic.com/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-api-tests
+ *
+ * When the script is added as synthetics check, it is recommend that it be set to check the custom URL
+ * no more than once a day.
+ * 
+ * The custom attributes added to the synthetics check will be found in the New Relic SyntheticCheck event
+ * sample table.
+ *
+ * Example
+ * SELECT * FROM SyntheticCheck WHERE monitorName = 'the-api-monitor-name'
+ *
+ * Results from NRQL query
+ * ...
+ *   "events": [
+ *     {
+ *       "custom.issuer": "Sectigo Limited",
+ *       "custom.remainingDays": 225,
+ *       "custom.url": "custom-url",
+ *       "custom.validTo": "2021-10-13T23:59:59.000Z",
+ *       "custom.failDaysBeforeExpiration": 30,
+ *       "custom.serialNumber": "ABBDD363634353"
+ * ...
+ */
+
+const assert = require('assert')
+const request = require('request')
+
+// EDIT: Put your custom URL here
+const url = 'https://enter-url-here'
+// EDIT: Days before your certification expires to fail the check and provide an alert
+const failDaysBeforeExpiration = 30
+
+const currentDate = new Date()
+
+$util.insights.set('url', url)
+console.log('Validating the certificate for ' + url)
+
+$util.insights.set('failDaysBeforeExpiration', failDaysBeforeExpiration)
+
+request({
+  url: url,
+  method: 'HEAD',
+  gzip: true,
+  followRedirect: false,
+  followAllRedirects: false
+}).on('response', (res) => {
+    // For more details about a certificate, review the object properties
+    // https://nodejs.org/api/tls.html#tls_certificate_object
+    var cert = res.req.connection.getPeerCertificate()
+    var validTo = new Date(cert.valid_to)
+
+    $util.insights.set('serialNumber', cert.serialNumber)
+    $util.insights.set('validTo', validTo)
+    console.log('This certificate ' + cert.serialNumber + ' will expire on ' + validTo)
+
+    $util.insights.set('issuer', cert.issuer.O)
+    console.log('Certificate was issued by ' + cert.issuer.O)
+
+    var remainingDays = getRemainingDays(validTo, currentDate)
+    console.log('Days left until expiration ' + remainingDays)
+    $util.insights.set('remainingDays', remainingDays)
+
+    // Subtract the failDaysBeforeExpiration from the certificate's expiration date
+    validTo.setDate(validTo.getDate() - failDaysBeforeExpiration)
+
+    if (validTo <= currentDate){
+      console.log('The certificate\'s date is not valid and should be updated.')
+    } else {
+      console.log('The certificate\'s date is valid.')
+    }
+
+     assert.ok(validTo > currentDate, "the certificate will expire in the next " + failDaysBeforeExpiration + "days.")
+  }
+)
+
+function getRemainingDays(expiration, current) {
+  return Math.floor((expiration.getTime() - current.getTime()) / (1000 * 60 * 60 * 24))
+}


### PR DESCRIPTION
The change adds an example of how to check for a Digital Certificate's (SSL or TLS) `valid_to` date and then asserts if it doesn't meet the time criteria so that an administrator can update it when required.