### PR TITLE
added a google lighthouse synthetic check

### DIFF
--- a/library/GoogleLighthouse/config.yml
+++ b/library/GoogleLighthouse/config.yml
@@ -1,0 +1,30 @@
+# Name of your quickstart as shown on the website
+name: Google PageSpeed Insights - Lighthouse
+description: >
+  Gets a Google Lighthouse Audit report using the PageSpeed
+  Insights API and stores the results, for analysis. Use cases
+  include comparing this data with Real User Monitoring (RUM)
+  data, monitoring Core Web Vitals and Lighthouse scores.
+  You need to create a secure credential called PAGESPEED_INSIGHTS_API_KEY.
+  More info on that here: https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/
+
+  You can get a PageSpeed Insights API key from Google here:
+    https://developers.google.com/speed/docs/insights/v5/get-started
+
+  You will also need to replace the URL to the page you want to check.
+  Current it is checking google.com by default.
+
+# Type of synthetic quickstart
+# - Template (Default): Full example that users can copy paste to use
+# - Snippet: Code example or building block for users to use in their own synthetic scripts
+type: Template
+
+# Type of synthetic monitor
+# Scripted Browser = SCRIPT_BROWSER
+# Scripted API = SCRIPT_API
+monitorType: SCRIPT_API
+
+# Optional: Authors of the quickstart
+authors:
+    - Dan Perovich
+    - Daniel Fitzgerald

--- a/library/GoogleLighthouse/script.js
+++ b/library/GoogleLighthouse/script.js
@@ -1,0 +1,38 @@
+/** API SETUP - remove this section to run in New Relic Synthetics **/
+// if ($http == null) { var $http = require('request'); }
+/** API SETUP - remove this section to run in New Relic Synthetics **/
+
+var settings = {'url': 'https://www.google.com', 'category': 'performance', 'strategy': 'desktop'};
+
+var options = {
+  method: 'GET',
+  url: 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?key=' + $secure.PAGESPEED_INSIGHTS_API_KEY,
+  headers: null,
+  qs: settings,
+  json: true
+};
+
+$http(options, function (error, response, body) {
+  if (!error && response.statusCode == 200) {
+    if (response.statusCode == 200) {
+      var lighthouseMetrics = body.lighthouseResult.audits.metrics.details.items[0];
+      $util.insights.set('url', settings.url);
+      $util.insights.set('deviceType', settings.strategy);
+      
+      for (var attributeName in lighthouseMetrics) {
+        if ( lighthouseMetrics.hasOwnProperty(attributeName) ) {
+          if (!attributeName.includes('Ts')) {
+            console.log(attributeName + ": " + lighthouseMetrics[attributeName]);
+            $util.insights.set(attributeName, lighthouseMetrics[attributeName]);
+          }
+        }
+      }
+      
+    } else {
+      console.log('Non-200 HTTP response: ' + response.statusCode);
+    }
+  } else {
+    console.log('rsp code: ' + response.statusCode);
+    console.log(error);
+  }
+});


### PR DESCRIPTION
Background: https://docs.google.com/document/d/14Uw_Te16QW75ROr7N3cgDCiBGPSw1EkAWvUUpmVmJ1A/edit#heading=h.2fuxfmiu211e

Uses Google PageSpeed Insights API to fetch a full Lighthouse audit and stores the results in TDP under `SyntheticCheck`