### PR TITLE
Added new quickstart

### DIFF
--- a/library/BrokenLinkChecker/config.yml
+++ b/library/BrokenLinkChecker/config.yml
@@ -1,0 +1,18 @@
+# Name of your quickstart as shown on the website
+name: Broken Link Checker
+description: >
+  Check all hyperlinks on a page for broken links
+
+# Type of synthetic quickstart
+# - Template (Default): Full example that users can copy paste to use
+# - Snippet: Code example or building block for users to use in their own synthetic scripts
+type: Template
+
+# Type of synthetic monitor
+# Scripted Browser = SCRIPT_BROWSER
+# Scripted API = SCRIPT_API
+monitorType: SCRIPT_BROWSER
+
+# Optional: Authors of the quickstart
+authors:
+    - Phil W.

--- a/library/BrokenLinkChecker/script.js
+++ b/library/BrokenLinkChecker/script.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const $http = require('request');
+const parse = require('url-parse');
+const By = $driver.By;
+
+// Replace with the URL you want to check for broken links
+const urlToCheck = 'https://www.example.com/';
+
+$browser.get(urlToCheck)
+  .then(function() {
+    // find all 'a' elements
+    return $browser.findElements(By.tagName('a'));
+  })
+  .then(function(links) {
+    // for each link...
+    return links.forEach(function(link) {
+      // get link target
+      return link.getAttribute('href')
+        .then(function(href) {
+          // if href is not missing or empty...
+          if (href != null && href != '') {
+            // skip mailto and tel links
+            if (!href.startsWith('mailto') && !href.startsWith('tel')) {
+              var domain = parse(href).hostname;
+              // if target is not in list of excluded domains...
+              if (domain != 'www.instagram.com' && domain != 'www.linkedin.com') {
+                // send HEAD request and check response
+                return $http.head(href, callback);
+              }
+            }
+          }
+        });
+    });
+  });
+
+  function callback(error, response, body) {
+    if (response != null) {
+      assert.ok(response.statusCode != 404, 'Broken link found: ' + response.request.uri.href);
+    }
+  }

--- a/library/BrokenLinkChecker/script.js
+++ b/library/BrokenLinkChecker/script.js
@@ -6,6 +6,11 @@ const By = $driver.By;
 // Replace with the URL you want to check for broken links
 const urlToCheck = 'https://www.example.com/';
 
+const domainsToIgnore = [
+  'www.instagram.com',
+  'www.linkedin.com'
+];
+
 $browser.get(urlToCheck)
   .then(function() {
     // find all 'a' elements
@@ -23,7 +28,7 @@ $browser.get(urlToCheck)
             if (!href.startsWith('mailto') && !href.startsWith('tel')) {
               var domain = parse(href).hostname;
               // if target is not in list of excluded domains...
-              if (domain != 'www.instagram.com' && domain != 'www.linkedin.com') {
+              if (!domainsToIgnore.includes(domain)) {
                 // send HEAD request and check response
                 return $http.head(href, callback);
               }


### PR DESCRIPTION
New quickstart: Broken Link Checker. Unlike the Broken Links monitor in the Synthetics product, this scripted browser excludes domains that always fail when visited by a bot, such as Instagram and LinkedIn. 