### PR TITLE
feat: Updated MFA example to use otpauth module

### DIFF
--- a/library/2FAOrMFA/config.yml
+++ b/library/2FAOrMFA/config.yml
@@ -1,9 +1,8 @@
 # Name of your quickstart as shown on the website
 name: 2FAOrMFA
 description: >
-  Use the speakeasy node module to create a time based one time password for Google Authenticator and Okta based 2FA/MFA. 
-  This module is not available in the Synthetics runtime environment and requires use of a containerized private minion with a custom npm module configuration:
-  https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#custom-modules
+  Use the otpauth node module to create a time based one time password for Google Authenticator and Okta based 2FA/MFA. 
+  This module is available on public and private locations when using the Chrome 100, Node 16.10.0, or newer runtimes. 
 
 # Type of synthetic quickstart
 # - Template (Default): Full example that users can copy paste to use

--- a/library/2FAOrMFA/script.js
+++ b/library/2FAOrMFA/script.js
@@ -1,17 +1,20 @@
-var speakeasy = require('speakeasy');
+var otpauth = require('otpauth');
 
 // The secret is the value obtained while setting up 2FA/MFA for your user and choosing the Can't scan the QR code option.
 // Capture this key and store it in a Secure Credential for use during monitor execution.
 var secret = $secure.TESTOKTAMFA;
 
 // This encoding and algorithm combination is used for Google Authenticator or Okta based TOTP.
-var MFAOptions = {
-  secret: secret,
-  encoding: 'base32',
-  algorithm: 'sha1'
-}
+let totp = new otpauth.TOTP({
+  algorithm: 'SHA1',
+  digits: 6,
+  period: 30,
+  secret: secret
+})
 
 // The scripted browser logic to navigate to the MFA screen would be located here. Find the object and then use this as the input to sendKeys.
 // Since this is time based, send the output to sendKeys directly instead of storing this in a variable at the top of your script.
-// Example: el.sendKeys(speakeasy.totp(MFAOptions)) where el is the element.
-speakeasy.totp(MFAOptions)
+// Example: el.sendKeys(totp.generate()) where el is the element.
+// This quickstart logs out the token instead of sending it to an element or as input to an API test.
+let token = totp.generate();
+console.log(token);


### PR DESCRIPTION
Updated the 2FA/MFA example to use the otpauth module instead of speakeasy. The otpauth module is now available in the Chrome 100 and Node 16.10.0 runtimes for public and private locations. 