### PR TITLE
fix(GoogleLighthouse): refactor for node-16.10 runtime

### DIFF
--- a/library/GoogleLighthouse/script.js
+++ b/library/GoogleLighthouse/script.js
@@ -2,38 +2,35 @@
 // if ($http == null) { var $http = require('request'); }
 /** API SETUP - remove this section to run in New Relic Synthetics **/
 
-var settings = {'url': 'https://www.google.com', 'category': 'performance', 'strategy': 'desktop'};
+const settings = {'url': 'https://www.google.com', 'category': 'performance', 'strategy': 'desktop'};
 
-var options = {
+const options = {
   method: 'GET',
   url: 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?key=' + $secure.PAGESPEED_INSIGHTS_API_KEY,
-  headers: null,
-  qs: settings,
-  json: true
+  headers: undefined,
+  searchParams: settings
 };
 
-$http(options, function (error, response, body) {
-  if (!error && response.statusCode == 200) {
-    if (response.statusCode == 200) {
-      var lighthouseMetrics = body.lighthouseResult.audits.metrics.details.items[0];
-      $util.insights.set('url', settings.url);
-      $util.insights.set('deviceType', settings.strategy);
-      $util.insights.set('performanceScore', body.lighthouseResult.categories.performance.score);
-      
-      for (var attributeName in lighthouseMetrics) {
-        if ( lighthouseMetrics.hasOwnProperty(attributeName) ) {
-          if (!attributeName.includes('Ts')) {
-            console.log(attributeName + ": " + lighthouseMetrics[attributeName]);
-            $util.insights.set(attributeName, lighthouseMetrics[attributeName]);
-          }
+try {
+	const response = $http(options);
+  if (response.statusCode == 200) {
+    const lighthouseMetrics = response.body.lighthouseResult.audits.metrics.details.items[0];
+    $util.insights.set('url', settings.url);
+    $util.insights.set('deviceType', settings.strategy);
+    $util.insights.set('performanceScore', response.body.lighthouseResult.categories.performance.score);
+
+    for (let attributeName in lighthouseMetrics) {
+      if ( lighthouseMetrics.hasOwnProperty(attributeName) ) {
+        if (!attributeName.includes('Ts')) {
+          console.log(attributeName + ": " + lighthouseMetrics[attributeName]);
+          $util.insights.set(attributeName, lighthouseMetrics[attributeName]);
         }
       }
-      
-    } else {
-      console.log('Non-200 HTTP response: ' + response.statusCode);
     }
+
   } else {
-    console.log('rsp code: ' + response.statusCode);
-    console.log(error);
+    console.log('Non-200 HTTP response: ' + response.statusCode);
   }
-});
+} catch (error) {
+  console.log(error);
+}

--- a/library/GoogleLighthouse/script.js
+++ b/library/GoogleLighthouse/script.js
@@ -12,7 +12,7 @@ const options = {
 };
 
 try {
-	const response = $http(options);
+  const response = $http(options);
   if (response.statusCode == 200) {
     const lighthouseMetrics = response.body.lighthouseResult.audits.metrics.details.items[0];
     $util.insights.set('url', settings.url);


### PR DESCRIPTION
The existing GoogleLighthouse script is not compatible with New Relic's Node.js 16.10 Runtime. I only had to make subtle modifications to get it running in both the v10 and v16.10 runtimes. This pull-request represents those changes.

I have tested this script in [both New Relic Runtimes](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/) and confirmed that Lighthouse Metrics are being recorded properly in New Relic Insights data.