### PR TITLE
Added MQTT example

### DIFF
--- a/library/MQTT/config.yml
+++ b/library/MQTT/config.yml
@@ -1,0 +1,20 @@
+# Name of your quickstart as shown on the website
+name: MQTT
+description: >
+  Connect to a MQTT server, subscribe to a topic, publish a message, and log out the message. 
+  Asserts could be added to validate the content of the message. 
+  Requires the use of a private location with a custom node module configuration to make the mqtt module available in the monitor.
+
+# Type of synthetic quickstart
+# - Template (Default): Full example that users can copy paste to use
+# - Snippet: Code example or building block for users to use in their own synthetic scripts
+type: Template
+
+# Type of synthetic monitor
+# Scripted Browser = SCRIPT_BROWSER
+# Scripted API = SCRIPT_API
+monitorType: SCRIPT_API
+
+# Optional: Authors of the quickstart
+authors:
+    - Brian P.

--- a/library/MQTT/script.js
+++ b/library/MQTT/script.js
@@ -1,0 +1,48 @@
+/**
+ * This requires the use of a private location and support for custom Node modules from Job Manager (https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules) so that the mqtt module will be available.
+*/
+
+const mqtt = require("mqtt");
+const assert = require("assert");
+
+// Custom timers
+const MQTTConnectTimer = $har.addResource("MQTT Connect")
+const MQTTSubscribeTimer = $har.addResource("MQTT Subscribe");
+const MQTTPublishTimer = $har.addResource("MQTT Publish");
+
+MQTTConnectTimer.startTimer();
+
+// Use secure credentials to manage usernames and passwords.
+const client = mqtt.connect({
+  host: 'REPLACEME',
+  port: 1884,
+  username: "REPLACEME",
+  password: "REPLACEME", 
+  connectTimeout: 30000
+});
+
+client.on("error", (error) => {
+  MQTTConnectTimer.endTimer();
+  throw new Error("Unable to connect to MQTT server! "+error);
+})
+
+// Subscribe to the synthetics topic when connected
+client.on("connect", () => {
+  MQTTConnectTimer.endTimer();
+  
+  MQTTSubscribeTimer.startTimer();
+  client.subscribe("synthetics", (err) => {
+    MQTTSubscribeTimer.endTimer();
+    assert(!err, "Error subscribing to test topic: "+ err)
+    MQTTPublishTimer.startTimer();
+    client.publish("synthetics", "Hello synthetics");
+  });
+});
+
+// Log out messages received
+client.on("message", (topic, message) => {
+  MQTTPublishTimer.endTimer();
+  // message is Buffer
+  console.log(message.toString());
+  client.end();
+});


### PR DESCRIPTION
Added an example of MQTT testing. This requires the use of a private location and configuring Synthetics Job Manager to make the mqtt module available for use (https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)